### PR TITLE
fix: Bool|Nil cast for sync= on Crystal 1.20.1

### DIFF
--- a/src/term-reader.cr
+++ b/src/term-reader.cr
@@ -99,7 +99,7 @@ module Term
       yield
     ensure
       begin
-        @output.as(IO::FileDescriptor).sync = !!buffering
+        @output.as(IO::FileDescriptor).sync = buffering || false
       rescue
       end
     end


### PR DESCRIPTION
## Problem
`IO::FileDescriptor#sync?` returns `Bool | Nil`. Assigning the raw result to `sync=` raises a compile-time type error on Crystal 1.20.1 because the union type `Bool | Nil` is not accepted where plain `Bool` is expected.

The previous attempt to coerce with `!!` still passes the union type to the setter and fails under the same checker.

## Fix
Change `!!buffering` → `buffering || false` so the RHS is always plain `Bool`.

## Tested
fff (crystal-port branch) builds and all 131 specs pass with this change applied locally against term-reader ~> 0.3.0.

Cc #8